### PR TITLE
Select fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 
-## v0.4.0
+## v0.5.0
+
+* Added support for `:select` query option, to select specific fields from the database.
+
+## v0.5.0
 
 * Added support for `new_#{record}` function
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Added support for `:select` query option, to select specific fields from the database.
 
-## v0.5.0
+## v0.4.0
 
 * Added support for `new_#{record}` function
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add `context_kit` to your list of dependencies in `mix.exs`:
 
     def deps do
       [
-        {:context_kit, "~> 0.4.0"}
+        {:context_kit, "~> 0.5.0"}
       ]
     end
 

--- a/lib/context_kit/query.ex
+++ b/lib/context_kit/query.ex
@@ -75,7 +75,8 @@ defmodule ContextKit.Query do
     :limit,
     :order_by,
     :paginate,
-    :preload
+    :preload,
+    :select
   ]
 
   def new(schema) do
@@ -319,6 +320,10 @@ defmodule ContextKit.Query do
 
   defp apply_query_option({:limit, limit}, query, _binding_name) do
     limit(query, ^limit)
+  end
+
+  defp apply_query_option({:select, fields}, query, _binding_name) do
+    select(query, ^fields)
   end
 
   defp apply_query_option({:preload, preload}, query, _binding_name) do

--- a/lib/context_kit/query.ex
+++ b/lib/context_kit/query.ex
@@ -63,6 +63,7 @@ defmodule ContextKit.Query do
     - `:limit` - Limit number of results
     - `:preload` - Preload associations
     - `:paginate` - Enable pagination with optional configuration
+    - `:select` - Select only specific fields from the database
   """
 
   import Ecto.Query

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ContextKit.MixProject do
   use Mix.Project
 
-  @version "0.4.0"
+  @version "0.5.0"
   @source_url "https://github.com/egze/context_kit"
 
   def project do

--- a/test/context_kit/crud/scoped_test.exs
+++ b/test/context_kit/crud/scoped_test.exs
@@ -107,7 +107,17 @@ defmodule ContextKit.CRUD.ScopedTest do
 
       assert [db_book] = ScopedBooks.list_scoped_books()
 
+      assert db_book.id == scoped_book.id
+      assert db_book.title == "My Book"
+    end
+
+    test "selects specific fields" do
+      assert {:ok, scoped_book} = Repo.insert(%ScopedBook{title: "My Book"})
+
+      assert [db_book] = ScopedBooks.list_scoped_books(select: [:id])
+
       assert scoped_book.id == db_book.id
+      assert db_book.title == nil
     end
 
     test "filters by scope" do

--- a/test/context_kit/crud_test.exs
+++ b/test/context_kit/crud_test.exs
@@ -54,7 +54,17 @@ defmodule ContextKit.CRUDTest do
 
       assert [db_book] = Books.list_books()
 
-      assert book.id == db_book.id
+      assert db_book.id == book.id
+      assert db_book.title == "My Book"
+    end
+
+    test "selects specific fields" do
+      assert {:ok, scoped_book} = Repo.insert(%Book{title: "My Book"})
+
+      assert [db_book] = Books.list_books(select: [:id])
+
+      assert scoped_book.id == db_book.id
+      assert db_book.title == nil
     end
 
     test "filters by fields in keyword list" do


### PR DESCRIPTION
Now you can select only the fields that you need with the `:select` option.

Example:
```elixir
Comments.list_comments(select: [:text])
```